### PR TITLE
Updated Front Motors to AK10-9

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ ROS2 Setup to perform MPC based Holonomic Navigation for Robotics: Planning and 
   ```
 
   Note: Ensure you've run `Import Libs` atleast once (or the equivalent command)
-
+- **To setup WiCAN** (only if working on hardware)
+    ```bash
+    sudo slcand -o -s8 -t sw -S 3000000 /dev/ttyUSB0 can0
+    sudo ifconfig can0 txqueuelen 1000
+    sudo ifconfig can0 up
+    ```
+    Note: You need to change `ttyUSB0` to the WiCAN device
 - **Launch**
 
   ```bash

--- a/robot_bringup/urdf/mecanum_drive.xacro.urdf
+++ b/robot_bringup/urdf/mecanum_drive.xacro.urdf
@@ -273,7 +273,7 @@
     </hardware>
     <joint name="front_left_wheel_joint">
       <param name="node_id">2</param>
-      <param name="model">AK60_6</param>
+      <param name="model">AK10_9</param>
       <param name="control_mode">velocity</param>
       <param name="kd">1.0</param>
       <param name="reduction">-1.0</param>
@@ -283,7 +283,7 @@
     </joint>
     <joint name="front_right_wheel_joint">
       <param name="node_id">1</param>
-      <param name="model">AK60_6</param>
+      <param name="model">AK10_9</param>
       <param name="control_mode">velocity</param>
       <param name="kd">1.0</param>
       <param name="reduction">1.0</param>


### PR DESCRIPTION
## Brief
In this PR
- Updated front 2 motors to AK10-9 due to shortage of AK60-6  (refer 701439397e515974991584d9f760e24cbd87b536)