### PR TITLE
Fixed Issues with Controller not connecting on NUC

### DIFF
--- a/.devcontainer/rosPkgs.list
+++ b/.devcontainer/rosPkgs.list
@@ -19,6 +19,7 @@ ros-humble-rosbag2-storage-mcap
 ros-humble-slam-toolbox
 ros-humble-navigation2
 ros-humble-nav2-bringup
+ros-humble-joy-linux
 iproute2
 can-utils
 net-tools

--- a/robot_bringup/CMakeLists.txt
+++ b/robot_bringup/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(robot_state_publisher REQUIRED)
 find_package(urdf REQUIRED)
-find_package(joy REQUIRED)
+find_package(joy_linux REQUIRED)
 find_package(teleop_twist_joy REQUIRED)
 
 install(

--- a/robot_bringup/config/joystick.yaml
+++ b/robot_bringup/config/joystick.yaml
@@ -1,5 +1,5 @@
 /**:
-  joy_node:
+  joy_linux_node:
     ros__parameters:
       device_id: 0
       deadzone: 0.05

--- a/robot_bringup/launch/joy.launch.py
+++ b/robot_bringup/launch/joy.launch.py
@@ -12,8 +12,8 @@ def generate_launch_description():
     joy_params = os.path.join(get_package_share_directory('robot_bringup'),'config','joystick.yaml')
 
     joy_node = Node(
-            package='joy',
-            executable='joy_node',
+            package='joy_linux',
+            executable='joy_linux_node',
             parameters=[joy_params, {'use_sim_time': use_sim_time}],
          )
 

--- a/robot_bringup/package.xml
+++ b/robot_bringup/package.xml
@@ -18,7 +18,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <exec_depend>joy</exec_depend>
+  <exec_depend>joy_linux</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
   <exec_depend>ld08_driver</exec_depend>
 


### PR DESCRIPTION
## Brief
Earlier we encountered an issue where the controller was not connecting on the NUC. After referring to https://github.com/ros-drivers/joystick_drivers/issues/278, it seems that a switch to `joy_linux` was necessary. 
 
Thus in this PR
- Added `joy_linux` dependencies
- Used same in launch file