### PR TITLE
Updated Hardware Interface Init

### DIFF
--- a/dep.repos
+++ b/dep.repos
@@ -6,7 +6,7 @@ repositories:
   rocon_hardware_interfaces:
     type: git
     url: https://github.com/RRC-Control-Lab/rocon_hardware_interfaces.git
-    version: main
+    version: feat/simplerinit
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git

--- a/robot_bringup/urdf/mecanum_drive.xacro.urdf
+++ b/robot_bringup/urdf/mecanum_drive.xacro.urdf
@@ -307,7 +307,7 @@
     </hardware>
     <joint name="front_left_wheel_joint">
       <param name="node_id">2</param>
-      <param name="model">AK10_9</param>
+      <param name="model">AK60_6</param>
       <param name="control_mode">velocity</param>
       <param name="kd">1.0</param>
       <param name="reduction">-1.0</param>
@@ -317,7 +317,7 @@
     </joint>
     <joint name="front_right_wheel_joint">
       <param name="node_id">1</param>
-      <param name="model">AK10_9</param>
+      <param name="model">AK60_6</param>
       <param name="control_mode">velocity</param>
       <param name="kd">1.0</param>
       <param name="reduction">1.0</param>


### PR DESCRIPTION
## Brief
In this PR
- Updated `rocon_hardware_interfaces` to new branch that supports the simpler initialisation procedure (refer 0172af91e08f4fe587ebafa2931605c5a74c28f2)
- Updated all motors to `AK60-6` in URDF (refer 6086b36aea96c9d1f5bf913ada0b488ff218c951)

### How was this tested?
Tested on mecanum drive